### PR TITLE
[#19] Run integration tests post-changes

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,6 +40,25 @@ jobs:
           DAS_REDIS_PORT=${{secrets.DAS_REDIS_PORT}} \
           faas-cli deploy -f ${{ env.DEPLOYMENT_FILE }}
 
+  testing-develop:
+    runs-on: ubuntu-latest
+    environment: develop
+    if: github.ref == 'refs/heads/develop'
+    needs: deploy-develop
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install requirements
+        run: pip3 install -r requirements.txt
+
+      - name: Run integration tests
+        run: |-
+          TEST_REMOTE_HOST=${{ vars.TEST_REMOTE_HOST }} \
+          TEST_REMOTE_PORT=${{ vars.TEST_REMOTE_PORT }} \
+          TEST_REMOTE_DATABASE=${{ vars.TEST_REMOTE_DATABASE }} \
+          make integration-tests
+
   deploy-production:
     runs-on: ubuntu-latest
     environment: production
@@ -70,3 +89,22 @@ jobs:
           DAS_REDIS_HOSTNAME=${{secrets.DAS_REDIS_HOSTNAME}} \
           DAS_REDIS_PORT=${{secrets.DAS_REDIS_PORT}} \
           faas-cli deploy -f ${{ env.DEPLOYMENT_FILE }}
+
+  testing-production:
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.ref == 'refs/heads/master'
+    needs: deploy-production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install requirements
+        run: pip3 install -r requirements.txt
+
+      - name: Run integration tests
+        run: |-
+          TEST_REMOTE_HOST=${{ vars.TEST_REMOTE_HOST }} \
+          TEST_REMOTE_PORT=${{ vars.TEST_REMOTE_PORT }} \
+          TEST_REMOTE_DATABASE=${{ vars.TEST_REMOTE_DATABASE }} \
+          make integration-tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vultr-openfaas-ssh-key
+__pycache__
+.pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+integration-tests:
+	pytest tests/integration/ -vv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest==7.4.3
+hyperon-das==0.4.0

--- a/tests/integration/fixtures/request/animals.json
+++ b/tests/integration/fixtures/request/animals.json
@@ -1,0 +1,45 @@
+{
+  "get_atom": {
+    "handle": "af12f10f9ae2002a1607ba0b47ba8407"
+  },
+  "get_node": {
+    "node_type": "Concept",
+    "node_name": "human"
+  },
+  "get_link": {
+    "link_type": "Similarity",
+    "link_targets": [
+      "af12f10f9ae2002a1607ba0b47ba8407",
+      "1cdffc6b0b89ff41d68bec237481d1e1"
+    ]
+  },
+  "get_links": {
+    "link_type": "Inheritance",
+    "link_targets": [
+      "4e8e26e3276af8a5c2ac2cc2dc95c6d2",
+      "80aff30094874e75028033a38ce677bb"
+    ]
+  },
+  "query": {
+    "query": {
+      "atom_type": "link",
+      "type": "Similarity",
+      "targets": [
+        {
+          "atom_type": "node",
+          "type": "Concept",
+          "name": "human"
+        },
+        {
+          "atom_type": "node",
+          "type": "Concept",
+          "name": "monkey"
+        }
+      ]
+    }
+  },
+  "get_incoming_links": {
+    "atom_handle": "af12f10f9ae2002a1607ba0b47ba8407",
+    "targets_document": true
+  }
+}

--- a/tests/integration/fixtures/request/bio.json
+++ b/tests/integration/fixtures/request/bio.json
@@ -1,0 +1,42 @@
+{
+  "get_atom": {
+    "handle": "e5032e6240ebe320f0c592daf9e3995f"
+  },
+  "get_node": {
+    "node_type": "Verbatim",
+    "node_name": "CG43315-PA"
+  },
+  "get_link": {
+    "link_type": "Inheritance",
+    "link_targets": [
+      "ca45e09ce8182135be0ba20e8e9552b9",
+      "05775a711209b2d4011e545b34ac02d0"
+    ]
+  },
+  "get_links": {
+    "link_type": "Inheritance",
+    "link_targets": [
+      "ca45e09ce8182135be0ba20e8e9552b9",
+      "05775a711209b2d4011e545b34ac02d0"
+    ]
+  },
+  "query": {
+    "query": {
+      "atom_type": "link",
+      "type": "Execution",
+      "targets": [
+        { "atom_type": "variable", "name": "v0" },
+        {
+          "atom_type": "node",
+          "type": "Verbatim",
+          "name": "Scer\\GAL4[Mef2.PR] CG3434[GD10969]"
+        },
+        { "atom_type": "variable", "name": "v1" }
+      ]
+    }
+  },
+  "get_incoming_links": {
+    "atom_handle": "ca45e09ce8182135be0ba20e8e9552b9",
+    "targets_document": true
+  }
+}

--- a/tests/integration/fixtures/response/animals.json
+++ b/tests/integration/fixtures/response/animals.json
@@ -1,0 +1,285 @@
+{
+  "count_atoms": [14, 26],
+  "get_atom": {
+    "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+    "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+    "name": "human",
+    "named_type": "Concept"
+  },
+  "get_node": {
+    "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+    "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+    "name": "human",
+    "named_type": "Concept"
+  },
+  "get_link": {
+    "handle": "bad7472f41a0e7d601ca294eb4607c3a",
+    "composite_type_hash": "ed73ea081d170e1d89fc950820ce1cee",
+    "is_toplevel": true,
+    "composite_type": [
+      "a9dea78180588431ec64d6bc4872fdbc",
+      "d99a604c79ce3c2e76a2f43488d5d4c3",
+      "d99a604c79ce3c2e76a2f43488d5d4c3"
+    ],
+    "named_type": "Similarity",
+    "named_type_hash": "a9dea78180588431ec64d6bc4872fdbc",
+    "targets": [
+      "af12f10f9ae2002a1607ba0b47ba8407",
+      "1cdffc6b0b89ff41d68bec237481d1e1"
+    ]
+  },
+  "get_links": [
+    {
+      "handle": "ee1c03e6d1f104ccd811cfbba018451a",
+      "type": "Inheritance",
+      "targets": [
+        "4e8e26e3276af8a5c2ac2cc2dc95c6d2",
+        "80aff30094874e75028033a38ce677bb"
+      ]
+    }
+  ],
+  "query": [
+    {
+      "handle": "bad7472f41a0e7d601ca294eb4607c3a",
+      "type": "Similarity",
+      "targets": [
+        {
+          "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+          "type": "Concept",
+          "name": "human"
+        },
+        {
+          "handle": "1cdffc6b0b89ff41d68bec237481d1e1",
+          "type": "Concept",
+          "name": "monkey"
+        }
+      ]
+    }
+  ],
+  "get_incoming_links": [
+    [
+      {
+        "handle": "2c927fdc6c0f1272ee439ceb76a6d1a4",
+        "composite_type_hash": "ed73ea081d170e1d89fc950820ce1cee",
+        "is_toplevel": true,
+        "composite_type": [
+          "a9dea78180588431ec64d6bc4872fdbc",
+          "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "d99a604c79ce3c2e76a2f43488d5d4c3"
+        ],
+        "named_type": "Similarity",
+        "named_type_hash": "a9dea78180588431ec64d6bc4872fdbc",
+        "targets": [
+          "5b34c54bee150c04f9fa584b899dc030",
+          "af12f10f9ae2002a1607ba0b47ba8407"
+        ]
+      },
+      [
+        {
+          "handle": "5b34c54bee150c04f9fa584b899dc030",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "chimp",
+          "named_type": "Concept"
+        },
+        {
+          "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "human",
+          "named_type": "Concept"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "2a8a69c01305563932b957de4b3a9ba6",
+        "composite_type_hash": "ed73ea081d170e1d89fc950820ce1cee",
+        "is_toplevel": true,
+        "composite_type": [
+          "a9dea78180588431ec64d6bc4872fdbc",
+          "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "d99a604c79ce3c2e76a2f43488d5d4c3"
+        ],
+        "named_type": "Similarity",
+        "named_type_hash": "a9dea78180588431ec64d6bc4872fdbc",
+        "targets": [
+          "1cdffc6b0b89ff41d68bec237481d1e1",
+          "af12f10f9ae2002a1607ba0b47ba8407"
+        ]
+      },
+      [
+        {
+          "handle": "1cdffc6b0b89ff41d68bec237481d1e1",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "monkey",
+          "named_type": "Concept"
+        },
+        {
+          "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "human",
+          "named_type": "Concept"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "bad7472f41a0e7d601ca294eb4607c3a",
+        "composite_type_hash": "ed73ea081d170e1d89fc950820ce1cee",
+        "is_toplevel": true,
+        "composite_type": [
+          "a9dea78180588431ec64d6bc4872fdbc",
+          "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "d99a604c79ce3c2e76a2f43488d5d4c3"
+        ],
+        "named_type": "Similarity",
+        "named_type_hash": "a9dea78180588431ec64d6bc4872fdbc",
+        "targets": [
+          "af12f10f9ae2002a1607ba0b47ba8407",
+          "1cdffc6b0b89ff41d68bec237481d1e1"
+        ]
+      },
+      [
+        {
+          "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "human",
+          "named_type": "Concept"
+        },
+        {
+          "handle": "1cdffc6b0b89ff41d68bec237481d1e1",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "monkey",
+          "named_type": "Concept"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "c93e1e758c53912638438e2a7d7f7b7f",
+        "composite_type_hash": "41c082428b28d7e9ea96160f7fd614ad",
+        "is_toplevel": true,
+        "composite_type": [
+          "e40489cd1e7102e35469c937e05c8bba",
+          "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "d99a604c79ce3c2e76a2f43488d5d4c3"
+        ],
+        "named_type": "Inheritance",
+        "named_type_hash": "e40489cd1e7102e35469c937e05c8bba",
+        "targets": [
+          "af12f10f9ae2002a1607ba0b47ba8407",
+          "bdfe4e7a431f73386f37c6448afe5840"
+        ]
+      },
+      [
+        {
+          "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "human",
+          "named_type": "Concept"
+        },
+        {
+          "handle": "bdfe4e7a431f73386f37c6448afe5840",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "mammal",
+          "named_type": "Concept"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "a45af31b43ee5ea271214338a5a5bd61",
+        "composite_type_hash": "ed73ea081d170e1d89fc950820ce1cee",
+        "is_toplevel": true,
+        "composite_type": [
+          "a9dea78180588431ec64d6bc4872fdbc",
+          "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "d99a604c79ce3c2e76a2f43488d5d4c3"
+        ],
+        "named_type": "Similarity",
+        "named_type_hash": "a9dea78180588431ec64d6bc4872fdbc",
+        "targets": [
+          "4e8e26e3276af8a5c2ac2cc2dc95c6d2",
+          "af12f10f9ae2002a1607ba0b47ba8407"
+        ]
+      },
+      [
+        {
+          "handle": "4e8e26e3276af8a5c2ac2cc2dc95c6d2",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "ent",
+          "named_type": "Concept"
+        },
+        {
+          "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "human",
+          "named_type": "Concept"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "16f7e407087bfa0b35b13d13a1aadcae",
+        "composite_type_hash": "ed73ea081d170e1d89fc950820ce1cee",
+        "is_toplevel": true,
+        "composite_type": [
+          "a9dea78180588431ec64d6bc4872fdbc",
+          "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "d99a604c79ce3c2e76a2f43488d5d4c3"
+        ],
+        "named_type": "Similarity",
+        "named_type_hash": "a9dea78180588431ec64d6bc4872fdbc",
+        "targets": [
+          "af12f10f9ae2002a1607ba0b47ba8407",
+          "4e8e26e3276af8a5c2ac2cc2dc95c6d2"
+        ]
+      },
+      [
+        {
+          "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "human",
+          "named_type": "Concept"
+        },
+        {
+          "handle": "4e8e26e3276af8a5c2ac2cc2dc95c6d2",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "ent",
+          "named_type": "Concept"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "b5459e299a5c5e8662c427f7e01b3bf1",
+        "composite_type_hash": "ed73ea081d170e1d89fc950820ce1cee",
+        "is_toplevel": true,
+        "composite_type": [
+          "a9dea78180588431ec64d6bc4872fdbc",
+          "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "d99a604c79ce3c2e76a2f43488d5d4c3"
+        ],
+        "named_type": "Similarity",
+        "named_type_hash": "a9dea78180588431ec64d6bc4872fdbc",
+        "targets": [
+          "af12f10f9ae2002a1607ba0b47ba8407",
+          "5b34c54bee150c04f9fa584b899dc030"
+        ]
+      },
+      [
+        {
+          "handle": "af12f10f9ae2002a1607ba0b47ba8407",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "human",
+          "named_type": "Concept"
+        },
+        {
+          "handle": "5b34c54bee150c04f9fa584b899dc030",
+          "composite_type_hash": "d99a604c79ce3c2e76a2f43488d5d4c3",
+          "name": "chimp",
+          "named_type": "Concept"
+        }
+      ]
+    ]
+  ]
+}

--- a/tests/integration/fixtures/response/bio.json
+++ b/tests/integration/fixtures/response/bio.json
@@ -1,0 +1,660 @@
+{
+  "count_atoms": [4367781, 9541360],
+  "get_atom": {
+    "handle": "e5032e6240ebe320f0c592daf9e3995f",
+    "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+    "name": "CG43315-PA",
+    "named_type": "Verbatim"
+  },
+  "get_node": {
+    "handle": "e5032e6240ebe320f0c592daf9e3995f",
+    "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+    "name": "CG43315-PA",
+    "named_type": "Verbatim"
+  },
+  "get_link": {
+    "handle": "1c33baa7e76f219d0d4b1832c5e31a72",
+    "composite_type_hash": "6c70086e4588bc7af1e65d5a177ca6b9",
+    "is_toplevel": true,
+    "composite_type": [
+      "e40489cd1e7102e35469c937e05c8bba",
+      "9125d6de13eac2095f2dfc0d817bba12",
+      "9125d6de13eac2095f2dfc0d817bba12"
+    ],
+    "named_type": "Inheritance",
+    "named_type_hash": "e40489cd1e7102e35469c937e05c8bba",
+    "targets": [
+      "ca45e09ce8182135be0ba20e8e9552b9",
+      "05775a711209b2d4011e545b34ac02d0"
+    ]
+  },
+  "get_links": [
+    {
+      "handle": "1c33baa7e76f219d0d4b1832c5e31a72",
+      "type": "Inheritance",
+      "targets": [
+        "ca45e09ce8182135be0ba20e8e9552b9",
+        "05775a711209b2d4011e545b34ac02d0"
+      ]
+    }
+  ],
+  "query": [
+    {
+      "handle": "e133d5f7238aece77acdd5e278234d6e",
+      "type": "Execution",
+      "targets": [
+        {
+          "handle": "e6a9f60bf58cfe9eb6ea3d261719ac68",
+          "type": "Schema",
+          "name": "Schema:genotype_phenotype_data_genotype_FBids"
+        },
+        {
+          "handle": "3b0234ae79a2d8de449a7206d8be7c62",
+          "type": "Verbatim",
+          "name": "Scer\\GAL4[Mef2.PR] CG3434[GD10969]"
+        },
+        {
+          "handle": "b0b759bfd8e5af89e941e6b49c277ee1",
+          "type": "Verbatim",
+          "name": "FBal0052385 FBal0203828"
+        }
+      ]
+    },
+    {
+      "handle": "2e80e13a2a795d8d9174b6067575b22e",
+      "type": "Execution",
+      "targets": [
+        {
+          "handle": "e6a9f60bf58cfe9eb6ea3d261719ac68",
+          "type": "Schema",
+          "name": "Schema:genotype_phenotype_data_genotype_FBids"
+        },
+        {
+          "handle": "3b0234ae79a2d8de449a7206d8be7c62",
+          "type": "Verbatim",
+          "name": "Scer\\GAL4[Mef2.PR] CG3434[GD10969]"
+        },
+        {
+          "handle": "0a4b2b96c908f8660bb0bf0202450453",
+          "type": "Verbatim",
+          "name": "FBal0203828"
+        }
+      ]
+    },
+    {
+      "handle": "636d4d8c160c3adf2ea432a9fd58dee2",
+      "type": "Execution",
+      "targets": [
+        {
+          "handle": "e6a9f60bf58cfe9eb6ea3d261719ac68",
+          "type": "Schema",
+          "name": "Schema:genotype_phenotype_data_genotype_FBids"
+        },
+        {
+          "handle": "3b0234ae79a2d8de449a7206d8be7c62",
+          "type": "Verbatim",
+          "name": "Scer\\GAL4[Mef2.PR] CG3434[GD10969]"
+        },
+        {
+          "handle": "e23c789eb15545c956c6bf59d46f6fe3",
+          "type": "Verbatim",
+          "name": "FBal0052385"
+        }
+      ]
+    }
+  ],
+  "get_incoming_links": [
+    [
+      {
+        "handle": "c0f937dcc1da7aa0e95ab1b047d70fd9",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "90041a559359049b02b3cc57f17697a1",
+          "ca45e09ce8182135be0ba20e8e9552b9",
+          "26b3b558c17b3c5899a5c8d22b4cdb25"
+        ]
+      },
+      [
+        {
+          "handle": "90041a559359049b02b3cc57f17697a1",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:gene_groups_HGNC_FB_group_symbol",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "26b3b558c17b3c5899a5c8d22b4cdb25",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "PVR-P",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "bf8ec5fe5c2783390188f5b8069d888e",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "cd391a276cbe0399840653f90e20f9d1",
+          "26b3b558c17b3c5899a5c8d22b4cdb25",
+          "ca45e09ce8182135be0ba20e8e9552b9"
+        ]
+      },
+      [
+        {
+          "handle": "cd391a276cbe0399840653f90e20f9d1",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:pathway_group_data_FB_group_id",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "26b3b558c17b3c5899a5c8d22b4cdb25",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "PVR-P",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "e89bfc31273908030262c401f61b4488",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "2fdcbcecf70d83144a1e5b97c19b710a",
+          "ca45e09ce8182135be0ba20e8e9552b9",
+          "823fb3e768aca055e7e35080753e4348"
+        ]
+      },
+      [
+        {
+          "handle": "2fdcbcecf70d83144a1e5b97c19b710a",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:pathway_group_data_Group_member_FB_gene_id",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "823fb3e768aca055e7e35080753e4348",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgn0015024",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "4db246e14f4cadc6aa2c9d12d380c908",
+        "composite_type_hash": "f5dee2f15fa3997b7b018e8f41553696",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "aae3c71672121c2397f9f81ff2eb7659",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "f83fbef11b44f93cabee7047526790c9",
+          "3822273636e4103f1cdc77beb93a372e",
+          "ca45e09ce8182135be0ba20e8e9552b9"
+        ]
+      },
+      [
+        {
+          "handle": "f83fbef11b44f93cabee7047526790c9",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:grp_uniquename",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "3822273636e4103f1cdc77beb93a372e",
+          "composite_type_hash": "aae3c71672121c2397f9f81ff2eb7659",
+          "name": "940",
+          "named_type": "grp"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "d23bb472eef6e1a4dcb41261e6f1d444",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "9b92fe78ab9c302e91b4b35a16c111d8",
+          "ca45e09ce8182135be0ba20e8e9552b9",
+          "26b3b558c17b3c5899a5c8d22b4cdb25"
+        ]
+      },
+      [
+        {
+          "handle": "9b92fe78ab9c302e91b4b35a16c111d8",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:pathway_group_data_FB_group_symbol",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "26b3b558c17b3c5899a5c8d22b4cdb25",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "PVR-P",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "1c33baa7e76f219d0d4b1832c5e31a72",
+        "composite_type_hash": "6c70086e4588bc7af1e65d5a177ca6b9",
+        "is_toplevel": true,
+        "composite_type": [
+          "e40489cd1e7102e35469c937e05c8bba",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Inheritance",
+        "named_type_hash": "e40489cd1e7102e35469c937e05c8bba",
+        "targets": [
+          "ca45e09ce8182135be0ba20e8e9552b9",
+          "05775a711209b2d4011e545b34ac02d0"
+        ]
+      },
+      [
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "05775a711209b2d4011e545b34ac02d0",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000972",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "6ee7b9134c90b9e0c8b235561df05aae",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "cd391a276cbe0399840653f90e20f9d1",
+          "823fb3e768aca055e7e35080753e4348",
+          "ca45e09ce8182135be0ba20e8e9552b9"
+        ]
+      },
+      [
+        {
+          "handle": "cd391a276cbe0399840653f90e20f9d1",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:pathway_group_data_FB_group_id",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "823fb3e768aca055e7e35080753e4348",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgn0015024",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "bd337a3d37b7e3d8dfa3126f030ae09b",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "cd391a276cbe0399840653f90e20f9d1",
+          "05775a711209b2d4011e545b34ac02d0",
+          "ca45e09ce8182135be0ba20e8e9552b9"
+        ]
+      },
+      [
+        {
+          "handle": "cd391a276cbe0399840653f90e20f9d1",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:pathway_group_data_FB_group_id",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "05775a711209b2d4011e545b34ac02d0",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000972",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "714ae048f33f3815b46c1e4d855e2d7b",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "2ca4c5f3086bf691aaca2c89766072a4",
+          "ca45e09ce8182135be0ba20e8e9552b9",
+          "05775a711209b2d4011e545b34ac02d0"
+        ]
+      },
+      [
+        {
+          "handle": "2ca4c5f3086bf691aaca2c89766072a4",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:pathway_group_data_Parent_FB_group_id",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "05775a711209b2d4011e545b34ac02d0",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000972",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "8fa92c37bb3ed5ea9efae0dc9425c9bd",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "9ab224e36f3d47dd944b12ea36c64d29",
+          "ca45e09ce8182135be0ba20e8e9552b9",
+          "25f7a35cf37ec59ea8fd11d5209ea021"
+        ]
+      },
+      [
+        {
+          "handle": "9ab224e36f3d47dd944b12ea36c64d29",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:gene_groups_HGNC_FB_group_name",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "25f7a35cf37ec59ea8fd11d5209ea021",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "Positive Regulators of Pvr Signaling Pathway",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "264b7b0c5e5e8769931728a8bc3ee85b",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "85fca056b51c61b427346e108d25c475",
+          "26b3b558c17b3c5899a5c8d22b4cdb25",
+          "ca45e09ce8182135be0ba20e8e9552b9"
+        ]
+      },
+      [
+        {
+          "handle": "85fca056b51c61b427346e108d25c475",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:gene_groups_HGNC_FB_group_id",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "26b3b558c17b3c5899a5c8d22b4cdb25",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "PVR-P",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "65d8c750b467869301fc46acb9cea29c",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "cd391a276cbe0399840653f90e20f9d1",
+          "25f7a35cf37ec59ea8fd11d5209ea021",
+          "ca45e09ce8182135be0ba20e8e9552b9"
+        ]
+      },
+      [
+        {
+          "handle": "cd391a276cbe0399840653f90e20f9d1",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:pathway_group_data_FB_group_id",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "25f7a35cf37ec59ea8fd11d5209ea021",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "Positive Regulators of Pvr Signaling Pathway",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "1569babb85cd7d16dd240d569ea4c677",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "85fca056b51c61b427346e108d25c475",
+          "25f7a35cf37ec59ea8fd11d5209ea021",
+          "ca45e09ce8182135be0ba20e8e9552b9"
+        ]
+      },
+      [
+        {
+          "handle": "85fca056b51c61b427346e108d25c475",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:gene_groups_HGNC_FB_group_id",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "25f7a35cf37ec59ea8fd11d5209ea021",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "Positive Regulators of Pvr Signaling Pathway",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        }
+      ]
+    ],
+    [
+      {
+        "handle": "2fd98ed1b0021d878c90656a25fd600e",
+        "composite_type_hash": "882a512e1fc3634f344ffae333fd60a2",
+        "is_toplevel": true,
+        "composite_type": [
+          "8f44785c8c19412c5b6611db30984514",
+          "7146a60667b422e69fd050fe1df6859a",
+          "9125d6de13eac2095f2dfc0d817bba12",
+          "9125d6de13eac2095f2dfc0d817bba12"
+        ],
+        "named_type": "Execution",
+        "named_type_hash": "8f44785c8c19412c5b6611db30984514",
+        "targets": [
+          "bd623e1bc1d5bc65be2745204f2637ba",
+          "ca45e09ce8182135be0ba20e8e9552b9",
+          "25f7a35cf37ec59ea8fd11d5209ea021"
+        ]
+      },
+      [
+        {
+          "handle": "bd623e1bc1d5bc65be2745204f2637ba",
+          "composite_type_hash": "7146a60667b422e69fd050fe1df6859a",
+          "name": "Schema:pathway_group_data_FB_group_name",
+          "named_type": "Schema"
+        },
+        {
+          "handle": "ca45e09ce8182135be0ba20e8e9552b9",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "FBgg0000975",
+          "named_type": "Verbatim"
+        },
+        {
+          "handle": "25f7a35cf37ec59ea8fd11d5209ea021",
+          "composite_type_hash": "9125d6de13eac2095f2dfc0d817bba12",
+          "name": "Positive Regulators of Pvr Signaling Pathway",
+          "named_type": "Verbatim"
+        }
+      ]
+    ]
+  ]
+}

--- a/tests/integration/test_remote_das.py
+++ b/tests/integration/test_remote_das.py
@@ -1,0 +1,126 @@
+import os
+import json
+from enum import Enum
+import pytest
+
+from hyperon_das import DistributedAtomSpace
+
+
+class ActionType(str, Enum):
+    COUNT_ATOMS = "count_atoms"
+    GET_ATOM = "get_atom"
+    GET_NODE = "get_node"
+    GET_LINK = "get_link"
+    GET_LINKS = "get_links"
+    GET_INCOMING_LINKS = "get_incoming_links"
+    QUERY = "query"
+
+
+class TestRemoteDistributedAtomSpace:
+    """Integration tests with OpenFaas function on the server"""
+
+    @pytest.fixture
+    def remote_das(self):
+        return DistributedAtomSpace(
+            query_engine="remote",
+            host=os.getenv("TEST_REMOTE_HOST"),
+            port=os.getenv("TEST_REMOTE_PORT"),
+        )
+
+    def get_request(self, action: ActionType):
+        request_file = f"{os.getenv('TEST_REMOTE_DATABASE')}.json"
+
+        current_path = os.path.dirname(os.path.abspath(__file__))
+        filepath = os.path.join(current_path, "fixtures", "request", request_file)
+
+        with open(filepath, "r") as file:
+            requests = json.loads(file.read())
+
+            return requests.get(action.value)
+
+    def get_response(self, action: ActionType):
+        response_file = f"{os.getenv('TEST_REMOTE_DATABASE')}.json"
+
+        current_path = os.path.dirname(os.path.abspath(__file__))
+        filepath = os.path.join(current_path, "fixtures", "response", response_file)
+
+        with open(filepath, "r") as file:
+            requests = json.loads(file.read())
+
+            return requests.get(action.value)
+
+    def test_server_connection(self):
+        host = os.getenv("TEST_REMOTE_HOST")
+        port = os.getenv("TEST_REMOTE_PORT")
+        try:
+            das = DistributedAtomSpace(query_engine="remote", host=host, port=port)
+        except Exception as e:
+            pytest.fail(f"Connection with OpenFaaS server fail, Details: {str(e)}")
+        if not das.query_engine.remote_das.url:
+            pytest.fail("Connection with server fail")
+        assert (
+            das.query_engine.remote_das.url
+            == f"http://{host}:{port}/function/query-engine"
+        )
+
+    def test_get_atom(self, remote_das: DistributedAtomSpace):
+        payload = self.get_request(ActionType.GET_ATOM)
+        expected_output = self.get_response(ActionType.GET_ATOM)
+
+        result = remote_das.get_atom(**payload)
+        assert (
+            result == expected_output
+        ), f"Assertion failed:\nResponse Body: {result}\nExpected: {json.dumps(expected_output)}"
+
+    def test_get_node(self, remote_das: DistributedAtomSpace):
+        payload = self.get_request(ActionType.GET_NODE)
+        expected_output = self.get_response(ActionType.GET_NODE)
+
+        result = remote_das.get_node(**payload)
+        assert (
+            result == expected_output
+        ), f"Assertion failed:\nResponse Body: {result}\nExpected: {json.dumps(expected_output)}"
+
+    def test_get_link(self, remote_das: DistributedAtomSpace):
+        payload = self.get_request(ActionType.GET_LINK)
+        expected_output = self.get_response(ActionType.GET_LINK)
+
+        result = remote_das.get_link(**payload)
+        assert (
+            result == expected_output
+        ), f"Assertion failed:\nResponse Body: {result}\nExpected: {json.dumps(expected_output)}"
+
+    def test_get_links(self, remote_das: DistributedAtomSpace):
+        payload = self.get_request(ActionType.GET_LINKS)
+        expected_output = self.get_response(ActionType.GET_LINKS)
+
+        result = remote_das.get_links(**payload)
+        assert (
+            result == expected_output
+        ), f"Assertion failed:\nResponse Body: {result}\nExpected: {json.dumps(expected_output)}"
+
+    def test_get_incoming_links(self, remote_das: DistributedAtomSpace):
+        payload = self.get_request(ActionType.GET_INCOMING_LINKS)
+        expected_output = self.get_response(ActionType.GET_INCOMING_LINKS)
+
+        result = remote_das.get_incoming_links(**payload)
+        assert (
+            result == expected_output
+        ), f"Assertion failed:\nResponse Body: {result}\nExpected: {json.dumps(expected_output)}"
+
+    def test_count_atoms(self, remote_das: DistributedAtomSpace):
+        expected_output = self.get_response(ActionType.COUNT_ATOMS)
+
+        result = list(remote_das.count_atoms())
+        assert (
+            result == expected_output
+        ), f"Assertion failed:\nResponse Body: {result}\nExpected: {json.dumps(expected_output)}"
+
+    def test_query(self, remote_das: DistributedAtomSpace):
+        payload = self.get_request(ActionType.QUERY)
+        expected_output = self.get_response(ActionType.QUERY)
+
+        result = remote_das.query(**payload)
+        assert (
+            result == expected_output
+        ), f"Assertion failed:\nResponse Body: {result}\nExpected: {json.dumps(expected_output)}"


### PR DESCRIPTION
After deploying the image to the server, we run a series of integration tests on the OpenFaaS server to ensure its health post-changes. If the pushed branch is 'develop', the tests run on the development server; otherwise, if it's 'master', they run on the production server.

Closes #19 